### PR TITLE
[Fixes sfjohnson/waterslide#1] Make shaderbox the full height of canvas

### DIFF
--- a/monitor/src/ShaderBox.svelte
+++ b/monitor/src/ShaderBox.svelte
@@ -122,7 +122,9 @@
     const uScalingFactor = gl.getUniformLocation(program, 'uScalingFactor')
     gl.uniform2fv(uScalingFactor, [dpr, dpr])
 
-    const vertArray = new Float32Array([-0.5, 0.5, 0.5, 0.5, 0.5, -0.5, -0.5, 0.5, 0.5, -0.5, -0.5, -0.5])
+    const vertArray = new Float32Array([
+      -0.5, 1, 0.5, 1, 0.5, -1, -0.5, 1, 0.5, -1, -0.5, -1,
+    ])
     const vertBuf = gl.createBuffer()
     const vertNumComponents = 2
     const vertCount = vertArray.length / vertNumComponents


### PR DESCRIPTION
[Fixes sfjohnson/waterslide#1]
Make shaderbox the full height of canvas.

The height of the total bar is fixed now. It goes from -1 to 1 on the y axis. Previously it was from -0.5 to 0.5.
However, due to this modification, i'm unsure if the axis values and the colored value parts of the bar are still correctly aligned or maybe needs re-calibration.
I was looking at the audio meter and the green bar seems to be fluctuating between 60 ~ 40 just by my typing. 
Is the audio meter in dBs? 
Does it (and the other meters) need recalibration?

![image](https://github.com/sfjohnson/waterslide/assets/1132037/a3788e05-2189-4901-8844-176486ca6ff6)
